### PR TITLE
Fix monitoring when new metrics are added

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,6 +76,7 @@ def pull_metrics(config: Config):
     json_data = res.json()
 
     update_metrics(json_data)
+    logger.info(f"Sent update to Prometheus")
 
 
 if __name__ == "__main__":
@@ -89,4 +90,4 @@ if __name__ == "__main__":
             time.sleep(config.pull_frequency_seconds)
             pull_metrics(config)
         except Exception as e:
-            logger.error(e)
+            logger.error("Error occurred while updating metrics: {}", e)

--- a/model.py
+++ b/model.py
@@ -177,24 +177,21 @@ TRIGGER = {name: Gauge(name, description) for name, description in trigger_data}
 GENERAL = {name: Gauge(name, description) for name, description in general_data}
 
 
-def update_metrics(data: Dict[str, Dict[str, int]]):
-    for key, value in data[DataCategoryConstants.Index].items():
-        INDEX[key].set(value)
-    for key, value in data[DataCategoryConstants.Operator].items():
-        OPERATOR[key].set(value)
-    for key, value in data[DataCategoryConstants.Query].items():
-        QUERY[key].set(value)
-    for key, value in data[DataCategoryConstants.QueryType].items():
-        QUERY_TYPE[key].set(value)
-    for key, value in data[DataCategoryConstants.Session].items():
-        SESSION[key].set(value)
-    for key, value in data[DataCategoryConstants.Snapshot].items():
-        SNAPSHOT[key].set(value)
-    for key, value in data[DataCategoryConstants.Stream].items():
-        STREAM[key].set(value)
-    for key, value in data[DataCategoryConstants.Transaction].items():
-        TRANSACTION[key].set(value)
-    for key, value in data[DataCategoryConstants.Trigger].items():
-        TRIGGER[key].set(value)
-    for key, value in data[DataCategoryConstants.General].items():
-        GENERAL[key].set(value)
+def update_prom_metrics(mg_data, prom_data):
+    for key, value in mg_data.items():
+        if key not in prom_data:
+            continue
+        prom_data[key].set(value)
+
+
+def update_metrics(mg_data: Dict[str, Dict[str, int]]):
+    update_prom_metrics(mg_data[DataCategoryConstants.Index], INDEX)
+    update_prom_metrics(mg_data[DataCategoryConstants.Operator], OPERATOR)
+    update_prom_metrics(mg_data[DataCategoryConstants.Query], QUERY)
+    update_prom_metrics(mg_data[DataCategoryConstants.QueryType], QUERY_TYPE)
+    update_prom_metrics(mg_data[DataCategoryConstants.Session], SESSION)
+    update_prom_metrics(mg_data[DataCategoryConstants.Snapshot], SNAPSHOT)
+    update_prom_metrics(mg_data[DataCategoryConstants.Stream], STREAM)
+    update_prom_metrics(mg_data[DataCategoryConstants.Transaction], TRANSACTION)
+    update_prom_metrics(mg_data[DataCategoryConstants.Trigger], TRIGGER)
+    update_prom_metrics(mg_data[DataCategoryConstants.General], GENERAL)


### PR DESCRIPTION
### Description

Prometheus exporter didn't work when there were some metrics exposed in Memgraph which weren't tracked in Prometheus.

### Related issues

Delete if this PR doesn't resolve any issues. Link the issue if it does.

######################################


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
