### PR TITLE
Add WalFilesRpc histogram HA metric

### DIFF
--- a/metrics/ha_metrics.py
+++ b/metrics/ha_metrics.py
@@ -14,6 +14,7 @@ def generate_timer_metrics(metric):
 ha_data_instances_metrics = (
     generate_timer_metrics("AppendDeltasRpc")
     + generate_timer_metrics("CurrentWalRpc")
+    + generate_timer_metrics("WalFilesRpc")
     + generate_timer_metrics("SnapshotRpc")
     + generate_timer_metrics("FrequentHeartbeatRpc")
     + generate_timer_metrics("HeartbeatRpc")
@@ -64,11 +65,11 @@ ha_coordinators_agg_metrics = [
     ),
     (
         "StateCheckRpcFail",
-        "How many times we received unsuccessful or no response to StateCheckRpc",
+        "How many times coordinators received unsuccessful or no response to StateCheckRpc",
     ),
     (
         "StateCheckRpcSuccess",
-        "How many times we received sucessful response to StateCheckRpc",
+        "How many times we received successful response to StateCheckRpc",
     ),
     (
         "UnregisterReplicaRpcFail",


### PR DESCRIPTION
### Description

WalFilesRpc wasn't included in the previous PR by accident. It is added here as histogram, tracking 50th, 90th and 99th percentile.

######################################


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Write a release note, including added/changed clauses
    - **Added HA metrics for tracking 50th, 90th and 99th percentile of WalFilesRpc.**
- [x] Link the documentation PR here
    - **[Documentation PR link](https://github.com/memgraph/documentation/pull/1196)**
- [x] Tag someone from docs team in the comments @katarinasupe 
