### PR TITLE
Add support for specifying configuration file parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN rm -rf .venv \
   && poetry install --no-interaction --no-ansi
 
 # Set an environment variable default to standalone
-ENV DEPLOYMENT_TYPE=standalone
+ENV DEPLOYMENT_TYPE=HA
+ENV CONFIG_FILE=/code/ha_config.yaml
 
 # Run main.py when the container launches
-ENTRYPOINT ["sh", "-c", "python3 mg_exporter.py --type=$DEPLOYMENT_TYPE"]
+ENTRYPOINT ["sh", "-c", "python3 mg_exporter.py --type=$DEPLOYMENT_TYPE --config-file=$CONFIG_FILE"]

--- a/README.md
+++ b/README.md
@@ -4,31 +4,47 @@
 
 The metrics currently collected can be found [in the documentation](https://memgraph.com/docs/configuration/monitoring-server#monitoring-via-http-server-enterprise).
 
-## Running the exporter
+## Running the exporter as Python script
 
 ```shell
 $ git clone https://github.com/memgraph/prometheus-exporter.git
 $ cd prometheus-exporter
 $ python3 -m pip install requests prometheus_client
-$ python3 mg_exporter.py --type={standalone,HA}
+$ python3 mg_exporter.py --type={standalone,HA} --config-file=config_file.yaml
 ```
 
-## Standalone exporter
+### Standalone exporter
 
 Standalone exporter can attach only to the single Memgraph instance. It can be started by running:
+
 ```bash
-python3 mg_exporter.py --type=standalone
+python3 mg_exporter.py --type=standalone --config-file=/code/standalone_config.yaml
 ```
+The file `standalone_config.yaml` serves as a template for your configuration file when running in standalone mode.
 
 Make sure to adjust host and port in `standalone_config.yaml`.
 
 
-## HA exporter
+### HA exporter
 
 High availability exporter attaches to multiple memgraph instances which are connected in cluster. It exposes for each instance all metrics
-which are exposed through standalone exporter but it also adds HA metrics. The full list of metrics used can be found on Memgraph docs.
+which are exposed through standalone exporter but it also adds HA metrics. The full list of metrics used can be found on [here](https://memgraph.com/docs/database-management/monitoring#ha-metrics).
+
+```bash
+python3 mg_exporter.py --type=HA --config-file=/code/ha_config.yaml
+```
+
+The file `ha_config.yaml` serves as a template for your configuration file when running in HA mode.
 
 Make sure to adjust url and port for each instance in the cluster in `ha_config.yaml` file.
+
+## Running through Docker
+
+The code is also available on DockerHub as `memgraph/prometheus-exporter`.
+
+```bash
+docker run -e DEPLOYMENT_TYPE=HA -e CONFIG_FILE=/etc/ha_config.yaml memgraph/prometheus-exporter
+```
 
 ## Running and Debugging the Setup
 

--- a/ha_config.yaml
+++ b/ha_config.yaml
@@ -1,3 +1,4 @@
+# Template for the configuration
 exporter:
   port: 9115
   pull_frequency_seconds: 5

--- a/ha_main.py
+++ b/ha_main.py
@@ -43,18 +43,38 @@ def pull_metrics(instance):
     res = requests.get(f"{instance.url}:{instance.port}")
 
     if res.status_code != 200:
-        raise Exception(f"Memgraph instance on {instance.url}:{instance.port} couldn't be reached.")
+        raise Exception(
+            f"Memgraph instance on {instance.url}:{instance.port} couldn't be reached."
+        )
 
     return res.json()
 
 
-def run():
-    config = load_yaml_config("ha_config.yaml")
-    instances = [InstanceConfig(name=instance['name'], url=instance['url'], port=instance['port'], type=instance["type"]) for instance in config.get('instances', [])]
-    instances_str = '\n\t'.join(str(instance) for instance in instances)
-    logger.info("HA exporter will use the following instances to collect metrics:\n\t%s", instances_str)
-    general_config = GeneralConfig(port=config.get('exporter', {}).get('port', 9115), pull_frequency_seconds=config.get('exporter', {}).get('pull_frequency_seconds', 0))
-    logger.info("HA exporter will pull metrics every %ds", general_config.pull_frequency_seconds)
+def run(config_file):
+    config = load_yaml_config(config_file)
+    instances = [
+        InstanceConfig(
+            name=instance["name"],
+            url=instance["url"],
+            port=instance["port"],
+            type=instance["type"],
+        )
+        for instance in config.get("instances", [])
+    ]
+    instances_str = "\n\t".join(str(instance) for instance in instances)
+    logger.info(
+        "HA exporter will use the following instances to collect metrics:\n\t%s",
+        instances_str,
+    )
+    general_config = GeneralConfig(
+        port=config.get("exporter", {}).get("port", 9115),
+        pull_frequency_seconds=config.get("exporter", {}).get(
+            "pull_frequency_seconds", 0
+        ),
+    )
+    logger.info(
+        "HA exporter will pull metrics every %ds", general_config.pull_frequency_seconds
+    )
     logger.info("HA exporter is started on: localhost:%s\n\n", general_config.port)
     exporter = HAExporterConfig(instances=instances, config=general_config)
 
@@ -73,4 +93,4 @@ def run():
 
 
 if __name__ == "__main__":
-    run()
+    run("ha_config.yaml")

--- a/mg_exporter.py
+++ b/mg_exporter.py
@@ -7,18 +7,18 @@ logger = logging.getLogger("prometheus_handler")
 logger.setLevel(logging.INFO)
 
 
-def main(deployment_type):
+def main(deployment_type, config_file):
     if deployment_type == "standalone":
         logger.info("Running in standalone mode.")
         import standalone_main
 
-        standalone_main.run()
+        standalone_main.run(config_file)
 
     elif deployment_type == "HA":
         logger.info("Running in High Availability (HA) mode.")
         import ha_main
 
-        ha_main.run()
+        ha_main.run(config_file)
     else:
         logger.error("Invalid deployment type. Please choose 'standalone' or 'HA'.")
 
@@ -34,7 +34,14 @@ if __name__ == "__main__":
         required=True,
         help="Type of deployment: standalone or HA",
     )
+    parser.add_argument(
+        "--config-file",
+        type=str,
+        default="standalone_config.yaml",
+        required=True,
+        help="Path to the config file needed to start standalone or HA exporter",
+    )
 
     args = parser.parse_args()
 
-    main(args.type)
+    main(args.type, args.config_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mg_exporter"
-version = "0.2.0"
+version = "0.2.1"
 description = "Prometheus exporter for Memgraph. Supports standalone and HA mode."
 authors = ["Josip Mrden <josip.mrden@memgraph.io>", "Andi Skrgat <andi.skrgat@memgraph.io>"]
 

--- a/standalone_main.py
+++ b/standalone_main.py
@@ -76,9 +76,9 @@ def pull_metrics(config: Config):
     logger.info("Sent update to Prometheus")
 
 
-def run():
+def run(config_file):
     # Parse the configuration for starting the service and retrieve data from correct endpoints
-    config = Config.from_yaml_file()
+    config = Config.from_yaml_file(file_name=config_file)
     start_http_server(config.exporter_port)
 
     # Continuously fetch metrics
@@ -91,4 +91,4 @@ def run():
 
 
 if __name__ == "__main__":
-    run()
+    run("standalone_config.yaml")


### PR DESCRIPTION
### Description

Memgraph exporter now supports argument `--config-file` so that users can change configuration with which exporter is started

### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [ ] Write a release note, including added/changed clauses
    - **The exporter can now be started with `--config-file` so that users can inject the configuration file. This should simplify the Docker and K8s deployment of this image. **
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
