### PR TITLE
Update HA metrics

### DIFF
--- a/metrics/ha_metrics.py
+++ b/metrics/ha_metrics.py
@@ -20,6 +20,8 @@ ha_data_instances_metrics = (
     + generate_timer_metrics("HeartbeatRpc")
     + generate_timer_metrics("ReplicaStream")
     + generate_timer_metrics("SystemRecoveryRpc")
+    + generate_timer_metrics("StartTxnReplication")
+    + generate_timer_metrics("FinalizeTxnReplication")
 )
 
 
@@ -36,6 +38,7 @@ ha_coordinator_metrics = (
     + generate_timer_metrics("RegisterReplicaOnMainRpc")
     + generate_timer_metrics("StateCheckRpc")
     + generate_timer_metrics("UnregisterReplicaRpc")
+    + generate_timer_metrics("DataFailover")
 )
 
 


### PR DESCRIPTION
### Description

New metrics are tracked, data failover duration and start/finish txn replication.



### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Write a release note, including added/changed clauses
    - **Memgraph now exposes a new set of metrics on HA cluster: how long the data failover takes and how long starting and finalising transaction takes on replica instances**
- [x] Link the documentation PR here
    - **[Documentation PR link](https://github.com/memgraph/documentation/pull/1283)**
- [x] Tag someone from docs team in the comments @matea16 
