### PR TITLE
feat: Optional TLS verify

### DIFF
--- a/ha_config.yaml
+++ b/ha_config.yaml
@@ -7,6 +7,10 @@ instances:
     url: http://127.0.0.1
     port: 9091
     type: coordinator
+    # When url is https://, you can either skip server cert verification or point
+    # at a CA bundle inside the container. skip_tls_verify wins if both are set.
+    # skip_tls_verify: false
+    # ca_file: /etc/ssl/certs/memgraph-ca.crt
   - name: coord2
     url: http://127.0.0.1
     port: 9092

--- a/ha_main.py
+++ b/ha_main.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import requests
+import urllib3
 import yaml
 
 from prometheus_client import start_http_server
@@ -18,14 +19,25 @@ class GeneralConfig:
 
 
 class InstanceConfig:
-    def __init__(self, name, url, port, type):
+    def __init__(self, name, url, port, type, skip_tls_verify=True, ca_file=None):
         self.name = name
         self.url = url
         self.port = port
         self.type = type
+        self.skip_tls_verify = skip_tls_verify
+        self.ca_file = ca_file
+        if self.skip_tls_verify and self.ca_file:
+            logger.warning(
+                "Instance %s has both skip_tls_verify=true and ca_file set; "
+                "skip_tls_verify takes precedence and ca_file is ignored.",
+                self.name,
+            )
 
     def __str__(self):
-        return f"InstanceConfig(name={self.name}, url={self.url}, port={self.port})"
+        return (
+            f"InstanceConfig(name={self.name}, url={self.url}, port={self.port}, "
+            f"skip_tls_verify={self.skip_tls_verify}, ca_file={self.ca_file})"
+        )
 
 
 class HAExporterConfig:
@@ -39,8 +51,18 @@ def load_yaml_config(filepath):
         return yaml.safe_load(file)
 
 
+def _verify_arg(instance):
+    if instance.skip_tls_verify:
+        return False
+    if instance.ca_file:
+        return instance.ca_file
+    return True
+
+
 def pull_metrics(instance):
-    res = requests.get(f"{instance.url}:{instance.port}")
+    res = requests.get(
+        f"{instance.url}:{instance.port}", verify=_verify_arg(instance)
+    )
 
     if res.status_code != 200:
         raise Exception(
@@ -58,9 +80,13 @@ def run(config_file):
             url=instance["url"],
             port=instance["port"],
             type=instance["type"],
+            skip_tls_verify=instance.get("skip_tls_verify", True),
+            ca_file=instance.get("ca_file"),
         )
         for instance in config.get("instances", [])
     ]
+    if any(inst.skip_tls_verify for inst in instances):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     instances_str = "\n\t".join(str(instance) for instance in instances)
     logger.info(
         "HA exporter will use the following instances to collect metrics:\n\t%s",

--- a/standalone_config.yaml
+++ b/standalone_config.yaml
@@ -3,5 +3,9 @@ exporter:
 memgraph:
   endpoint_url: http://127.0.0.1
   port: 9091
+  # When endpoint_url is https://, you can either skip server cert verification or
+  # point at a CA bundle inside the container. skip_tls_verify wins if both are set.
+  # skip_tls_verify: false
+  # ca_file: /etc/ssl/certs/memgraph-ca.crt
 general:
   pull_frequency_seconds: 5

--- a/standalone_main.py
+++ b/standalone_main.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import requests
+import urllib3
 import yaml
 
 from yaml.loader import SafeLoader
@@ -19,6 +20,8 @@ class ConfigConstants:
     MEMGRAPH = "memgraph"
     PORT = "port"
     PULL_FREQUENCY_SECONDS = "pull_frequency_seconds"
+    SKIP_TLS_VERIFY = "skip_tls_verify"
+    CA_FILE = "ca_file"
 
 
 class Config:
@@ -28,21 +31,33 @@ class Config:
         memgraph_port: int,
         exporter_port: int,
         pull_frequency_seconds: int,
+        skip_tls_verify: bool = True,
+        ca_file: str = None,
     ) -> None:
         self._memgraph_endpoint_url = memgraph_endpoint_url
         self._memgraph_port = memgraph_port
         self._exporter_port = exporter_port
         self._pull_frequency_seconds = pull_frequency_seconds
+        self._skip_tls_verify = skip_tls_verify
+        self._ca_file = ca_file
+        if self._skip_tls_verify and self._ca_file:
+            logger.warning(
+                "Both skip_tls_verify=true and ca_file set; "
+                "skip_tls_verify takes precedence and ca_file is ignored."
+            )
 
     @classmethod
     def from_yaml_file(cls, file_name: str = "standalone_config.yaml") -> "Config":
         with open(file_name) as f:
             data = yaml.load(f, Loader=SafeLoader)
+            memgraph = data[ConfigConstants.MEMGRAPH]
             return Config(
-                data[ConfigConstants.MEMGRAPH][ConfigConstants.ENDPOINT_URL],
-                data[ConfigConstants.MEMGRAPH][ConfigConstants.PORT],
+                memgraph[ConfigConstants.ENDPOINT_URL],
+                memgraph[ConfigConstants.PORT],
                 data[ConfigConstants.EXPORTER][ConfigConstants.PORT],
                 data[ConfigConstants.GENERAL][ConfigConstants.PULL_FREQUENCY_SECONDS],
+                memgraph.get(ConfigConstants.SKIP_TLS_VERIFY, True),
+                memgraph.get(ConfigConstants.CA_FILE),
             )
 
     @property
@@ -61,9 +76,28 @@ class Config:
     def pull_frequency_seconds(self) -> int:
         return self._pull_frequency_seconds
 
+    @property
+    def skip_tls_verify(self) -> bool:
+        return self._skip_tls_verify
+
+    @property
+    def ca_file(self):
+        return self._ca_file
+
+
+def _verify_arg(config: Config):
+    if config.skip_tls_verify:
+        return False
+    if config.ca_file:
+        return config.ca_file
+    return True
+
 
 def pull_metrics(config: Config):
-    res = requests.get(f"{config.memgraph_endpoint_url}:{config.memgraph_port}")
+    res = requests.get(
+        f"{config.memgraph_endpoint_url}:{config.memgraph_port}",
+        verify=_verify_arg(config),
+    )
 
     if res.status_code != 200:
         raise Exception(
@@ -79,6 +113,8 @@ def pull_metrics(config: Config):
 def run(config_file):
     # Parse the configuration for starting the service and retrieve data from correct endpoints
     config = Config.from_yaml_file(file_name=config_file)
+    if config.skip_tls_verify:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     start_http_server(config.exporter_port)
 
     # Continuously fetch metrics


### PR DESCRIPTION
### Description

Users can choose whether to just encrypt the communication or to set the ca file.

### Related issues

Delete if this PR doesn't resolve any issues. Link the issue if it does.

######################################


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Write a release note, including added/changed clauses
    - **When connecting to Memgraph db which has TLS server turned on, users can choose whether to skip verification and to just encrypt the communication or to use CA for cert verification.[#34]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments
